### PR TITLE
Fix failing React test

### DIFF
--- a/frontend/app/src/App.test.js
+++ b/frontend/app/src/App.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// The default CRA test looked for a "learn react" link which our
+// application does not render.  This caused the test suite to fail.
+// Update the test to assert that our main heading is present instead.
+test('renders application heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /ai detection tool/i });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Replace placeholder CRA test with one verifying that the AI Detection Tool heading renders.

## Testing
- `cd frontend/app && CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06c209944832ba7ecc766e184df2c