### PR TITLE
feat: enhance AI detection analysis

### DIFF
--- a/backend/server/logic.py
+++ b/backend/server/logic.py
@@ -1,0 +1,43 @@
+import math
+import re
+from collections import Counter
+from typing import Tuple
+
+
+def shannon_entropy(text: str) -> float:
+    """Calculate Shannon entropy of the input text."""
+    counts = Counter(text)
+    total = sum(counts.values())
+    if total == 0:
+        return 0.0
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def word_stats(text: str) -> Tuple[float, float]:
+    """Return average word length and its standard deviation."""
+    words = re.findall(r"\b\w+\b", text)
+    if not words:
+        return 0.0, 0.0
+    lengths = [len(w) for w in words]
+    avg = sum(lengths) / len(lengths)
+    variance = sum((l - avg) ** 2 for l in lengths) / len(lengths)
+    std_dev = math.sqrt(variance)
+    return avg, std_dev
+
+
+def analyse_text(text: str) -> tuple[float, str]:
+    """Analyse text and return a score and explanation."""
+    entropy = shannon_entropy(text)
+    avg_len, std_dev = word_stats(text)
+
+    def sigmoid(x: float) -> float:
+        return 1 / (1 + math.exp(-x))
+
+    entropy_component = sigmoid(entropy - 3.5)
+    variance_component = sigmoid(std_dev - 1.5)
+    score = (entropy_component + variance_component) / 2 * 100
+
+    explanation = (
+        f"Entropy={entropy:.2f}, Avg word length={avg_len:.2f}, Std dev={std_dev:.2f}"
+    )
+    return score, explanation

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from .logic import analyse_text as compute_score
 
 app = FastAPI()
 
@@ -19,14 +20,11 @@ class TextRequest(BaseModel):
     text: str
 
 
-
 @app.post("/analyse")
 def analyse_text(request: TextRequest):
-    score = 78
+    score, explanation = compute_score(request.text)
 
     return {
         "ai_score": score,
-        "explanation": "This text is AI written due to..."
+        "explanation": explanation,
     }
-
-

--- a/backend/server/test_logic.py
+++ b/backend/server/test_logic.py
@@ -1,0 +1,8 @@
+from logic import analyse_text
+
+
+def test_analyse_text_produces_score_and_explanation():
+    score, explanation = analyse_text("This is a simple test sentence for AI detection.")
+    assert isinstance(score, float)
+    assert 0 <= score <= 100
+    assert "Entropy" in explanation


### PR DESCRIPTION
## Summary
- compute AI score using Shannon entropy and word length variance
- expose advanced analysis in `/analyse` endpoint
- add test covering score and explanation

## Testing
- `cd backend/server && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06e3847c4832ba5e02fcc6949f086